### PR TITLE
Inspector improvements

### DIFF
--- a/src/Util/Inspector.php
+++ b/src/Util/Inspector.php
@@ -7,37 +7,33 @@
 
 namespace League\BooBoo\Util;
 
-use Exception;
-use ErrorException;
-use League\BooBoo\Util;
-
 class Inspector
 {
     /**
-     * @var Exception
+     * @var \Exception
      */
     private $exception;
 
     /**
-     * @var Util\FrameCollection
+     * @var FrameCollection
      */
     private $frames;
 
     /**
-     * @var Util\Inspector
+     * @var Inspector
      */
     private $previousExceptionInspector;
 
     /**
-     * @param Exception $exception The exception to inspect
+     * @param \Exception $exception The exception to inspect
      */
-    public function __construct(Exception $exception)
+    public function __construct(\Exception $exception)
     {
         $this->exception = $exception;
     }
 
     /**
-     * @return Exception
+     * @return \Exception
      */
     public function getException()
     {
@@ -83,18 +79,18 @@ class Inspector
     /**
      * Returns an iterator for the inspected exception's frames.
      *
-     * @return Util\FrameCollection
+     * @return FrameCollection
      */
     public function getFrames()
     {
         if ($this->frames === null) {
             $frames = $this->exception->getTrace();
 
-            // If we're handling an ErrorException thrown by BooBoo,
+            // If we're handling an \ErrorException thrown by BooBoo,
             // get rid of the last frame, which matches the handleError method,
             // and do not add the current exception to trace. We ensure that
             // the next frame does have a filename / linenumber, though.
-            if ($this->exception instanceof ErrorException) {
+            if ($this->exception instanceof \ErrorException) {
                 foreach ($frames as $k => $frame) {
                     if (isset($frame['class']) &&
                         strpos($frame['class'], 'BooBoo') !== false
@@ -116,5 +112,19 @@ class Inspector
         }
 
         return $this->frames;
+    }
+
+    /**
+     * Checks if the inspector has frames
+     *
+     * Note: this essentially generates the frames (which is usually done by the first call to getFrames)
+     *
+     * @return boolean
+     */
+    public function hasFrames()
+    {
+        $frames = $this->getFrames();
+
+        return count($frames) > 0;
     }
 }

--- a/src/Util/Inspector.php
+++ b/src/Util/Inspector.php
@@ -53,16 +53,9 @@ class Inspector
     }
 
     /**
-     * @return string
-     */
-    public function getExceptionMessage()
-    {
-        return $this->exception->getMessage();
-    }
-
-    /**
      * Does the wrapped Exception has a previous Exception?
-     * @return bool
+     *
+     * @return boolean
      */
     public function hasPreviousException()
     {
@@ -71,6 +64,7 @@ class Inspector
 
     /**
      * Returns an Inspector for a previous Exception, if any.
+     *
      * @return Inspector
      */
     public function getPreviousExceptionInspector()
@@ -87,8 +81,8 @@ class Inspector
     }
 
     /**
-     * Returns an iterator for the inspected exception's
-     * frames.
+     * Returns an iterator for the inspected exception's frames.
+     *
      * @return Util\FrameCollection
      */
     public function getFrames()

--- a/tests/unit/src/Util/InspectorTest.php
+++ b/tests/unit/src/Util/InspectorTest.php
@@ -32,5 +32,6 @@ class InspectorText extends PHPUnit_Framework_TestCase
     {
         $frames = $this->inspector->getFrames();
         $this->assertEquals(count($this->exception->getTrace()), count($frames));
+        $this->assertTrue($this->inspector->hasFrames());
     }
 }

--- a/tests/unit/src/Util/InspectorTest.php
+++ b/tests/unit/src/Util/InspectorTest.php
@@ -1,9 +1,11 @@
 <?php
 
+use League\BooBoo\Util\Inspector;
+
 class InspectorText extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var \League\BooBoo\Util\Inspector
+     * @var Inspector
      */
     protected $inspector;
 
@@ -15,7 +17,7 @@ class InspectorText extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->exception = new ErrorException('test message');
-        $this->inspector = new \League\BooBoo\Util\Inspector($this->exception);
+        $this->inspector = new Inspector($this->exception);
     }
 
     public function testGetters()
@@ -23,7 +25,6 @@ class InspectorText extends PHPUnit_Framework_TestCase
         $inspector = $this->inspector;
         $this->assertInstanceOf('ErrorException', $inspector->getException());
         $this->assertEquals('ErrorException', $inspector->getExceptionName());
-        $this->assertEquals('test message', $inspector->getExceptionMessage());
         $this->assertFalse($inspector->hasPreviousException());
     }
 


### PR DESCRIPTION
I did some changes in the inspector class based on the needs of the pretty page handler.

I also removed a function from the inspector which caused a little redundancy. Though originally the `getException` was meant to be removed, I decided to remove the `getExceptionMessage` because it made more sense to me.

The original discussion is here: filp/whoops#247.