### PR TITLE
Use PHP_EOL constant, to stop unit tests breaking on Windows

### DIFF
--- a/src/Util/Frame.php
+++ b/src/Util/Frame.php
@@ -186,7 +186,7 @@ class Frame implements Serializable
         $contents = $this->getFileContents();
 
         if (isset($contents)) {
-            $lines = explode("\n", $contents);
+            $lines = explode(PHP_EOL, $contents);
             // Get a subset of lines from $start to $end
             if ($length !== null) {
                 $start  = (int) $start;

--- a/tests/unit/src/Util/FrameTest.php
+++ b/tests/unit/src/Util/FrameTest.php
@@ -55,7 +55,7 @@ class FrameTest extends PHPUnit_Framework_TestCase {
 
     public function testGetFileContents()
     {
-        $this->assertEquals("test\ncontent", $this->frame->getFileContents());
+        $this->assertEquals("test" . PHP_EOL . "content", $this->frame->getFileContents());
     }
 
     public function testComments()


### PR DESCRIPTION
3 tests failing on windows due to use of "\n" for testing and in the getFileLines() function.  Swapped both to use PHP_EOL constant for platform neutrality. 