### PR TITLE
Added some middleware-like properties to exception handlers

### DIFF
--- a/src/BooBoo.php
+++ b/src/BooBoo.php
@@ -130,7 +130,7 @@ class BooBoo
     {
         http_response_code(500);
 
-        $this->runHandlers($e);
+        $e = $this->runHandlers($e);
 
         if (!$this->silenceErrors) {
             $formattedResponse = $this->runFormatters($e);
@@ -286,7 +286,10 @@ class BooBoo
     {
         /** @var \League\BooBoo\Handler\HandlerInterface $handler */
         foreach (array_reverse($this->handlerStack) as $handler) {
-            $handler->handle($e);
+            $handledException = $handler->handle($e);
+            if ($handledException instanceof \Exception) {
+                $e = $handledException;
+            }
         }
 
         return $e;


### PR DESCRIPTION
It would be really nice if the exception handlers could run in series like a middleware pattern.

For now, all I've done is allow handlers to return an exception. If they do this, the exception is passed along to the next handler in the chain.