### PR TITLE
Added missing spaces to markdown headlines

### DIFF
--- a/advantages.md
+++ b/advantages.md
@@ -4,7 +4,7 @@ permalink: advantages/
 title: Advantages
 ---
 
-#Advantages
+# Advantages
 
 BooBoo is designed to help make development easier while providing an integrated solution that can be deployed to
 your production environment. BooBoo offers the following advantages.

--- a/installing.md
+++ b/installing.md
@@ -4,7 +4,7 @@ permalink: installing-booboo/
 title: Installing BooBoo
 ---
 
-#Installing BooBoo
+# Installing BooBoo
 
 This library requires PHP 5.4 or later. It is not regularly tested against HHVM, but there is nothing in this package
 that should fail against HHVM. However, support is not guaranteed.

--- a/instantiation.md
+++ b/instantiation.md
@@ -4,7 +4,7 @@ permalink: instantiation/
 title: Instantiation
 ---
 
-#Instantiating BooBoo
+# Instantiating BooBoo
 
 The main object that you need to instantiate is League\BooBoo\BooBoo. This object takes care of setting the error
 handler, as well as handling errors and exceptions. It takes optional arguments during construction for handlers and


### PR DESCRIPTION
The headlines are not rendered properly without the spaces.